### PR TITLE
🚑 fix: incorrect main entry file path 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     }
   },
   "types": "./lib/cjs/types/index.d.ts",
-  "main": "./lib/cjs/index.js",
+  "main": "./lib/cjs/index.cjs",
   "type": "module",
   "files": [
     "lib/**/*"


### PR DESCRIPTION
### Summary
The file extension on the main entry file is incorrect. This PR just fixes that.

### Screenshots
<img width="300" alt="Screenshot 2024-06-25 at 05 10 50" src="https://github.com/Accountable-SA/accountable-jsvat/assets/12822259/8474f595-d6d2-4515-98a4-7e42b91a4281">

